### PR TITLE
Allow sparse text chunk positions in operation requests in Gateway API

### DIFF
--- a/src/dotnet/Gateway/Models/TextOperationContext.cs
+++ b/src/dotnet/Gateway/Models/TextOperationContext.cs
@@ -21,9 +21,9 @@ namespace FoundationaLLM.Gateway.Models
         public Func<TextChunk, bool> TextChunkCompletenessChecker { get; set; } = null!;
 
         /// <summary>
-        /// The list of <see cref="TextChunk"/> objects which provide the input to the text operation.
+        /// The position-indexed dictionary of <see cref="TextChunk"/> objects which provide the input to the text operation.
         /// </summary>
-        public required IList<TextChunk> InputTextChunks { get; set; } = [];
+        public required Dictionary<int, TextChunk> InputTextChunks { get; set; } = [];
 
         /// <summary>
         /// The <see cref="TextOperationResult"/> holding the result of the text operation.
@@ -82,7 +82,7 @@ namespace FoundationaLLM.Gateway.Models
                 foreach (var textChunk in  textChunks)
                 {
                     TextChunkUpdater(
-                        Result.TextChunks[textChunk.Position - 1],
+                        Result.TextChunks.Single(resultTextChunk => resultTextChunk.Position == textChunk.Position),
                         textChunk);
                 }
 

--- a/src/dotnet/Gateway/Services/ModelContext.cs
+++ b/src/dotnet/Gateway/Services/ModelContext.cs
@@ -100,8 +100,8 @@ namespace FoundationaLLM.Gateway.Services
                             if (_textOperationContexts.TryGetValue(operationId, out var textOperationContext)
                                 && textOperationContext.Result.InProgress)
                                 foreach (var inputTextChunk in textOperationContext.Result.TextChunks
-                                    .Where(tc => !textOperationContext.TextChunkCompletenessChecker(tc))
-                                    .Select(tc => textOperationContext.InputTextChunks[tc.Position - 1]))
+                                    .Where(resultTextChunk => !textOperationContext.TextChunkCompletenessChecker(resultTextChunk))
+                                    .Select(resultTextChunk => textOperationContext.InputTextChunks[resultTextChunk.Position]))
                                 {
                                     var modelDeploymentContext = DeploymentContexts[currentDeploymentContextIndex];
                                     if (!modelDeploymentContext.TryAddInputTextChunk(


### PR DESCRIPTION
# Allow sparse text chunk positions in operation requests in Gateway API

## The issue or feature being addressed

N/A

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
