### PR TITLE
Fix issue with matching attachment details in Core API

### DIFF
--- a/src/dotnet/Common/Models/Conversation/AttachmentDetail.cs
+++ b/src/dotnet/Common/Models/Conversation/AttachmentDetail.cs
@@ -46,7 +46,7 @@ namespace FoundationaLLM.Common.Models.Conversation
         /// <returns>The newly created <see cref="AttachmentDetail"/> instance.</returns>
         public static AttachmentDetail FromContextFileRecord(ContextFileRecord contextFileRecord) => new()
         {
-            ObjectId = contextFileRecord.Id,
+            ObjectId = contextFileRecord.FileObjectId,
             DisplayName = contextFileRecord.FileName,
             ContentType = contextFileRecord.ContentType
         };


### PR DESCRIPTION
# Fix issue with matching attachment details in Core API

## The Azure DevOps work item being addressed

[AB#69](https://dev.azure.com/foundationallm/46965626-a028-4da9-83d3-9723c4aa1e02/_workitems/edit/69)

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
