### PR TITLE
Fix issue with building file object id in agent private store update

### DIFF
--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -1580,7 +1580,7 @@ namespace FoundationaLLM.Agent.ResourceProviders
                     $"The agent {agent.Name} does not have the required knowledge search settings set.");
             var fileResourcePath = ResourcePath.GetResourcePath(fileObjectId);
             var fileId =
-                $"/instances/{instanceId}/providers/FoundationaLLM.ContextAPI/files/{fileResourcePath.ResourceId!}";
+                $"/instances/{instanceId}/providers/{ResourceProviderNames.FoundationaLLM_Context}/files/{fileResourcePath.ResourceId!}";
 
             var newDataPipelineRun = DataPipelineRun.Create(
                 knowledgeSearchSettings.FileUploadDataPipelineObjectId,


### PR DESCRIPTION
# Fix issue with building file object id in agent private store update

## The Azure DevOps work item being addressed

[AB#59](https://dev.azure.com/foundationallm/46965626-a028-4da9-83d3-9723c4aa1e02/_workitems/edit/59)

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
