### PR TITLE
Fix issue with incorrect tool name in file tool association

### DIFF
--- a/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
+++ b/src/dotnet/Agent/ResourceProviders/AgentResourceProviderService.cs
@@ -1484,7 +1484,7 @@ namespace FoundationaLLM.Agent.ResourceProviders
 
                     break;
 
-                case AgentToolNames.FoundationaLLMCodeInterpreterTool:
+                case AgentToolNames.FoundationaLLMKnowledgeSearchTool:
                     agent = await GetResourceAsync<AgentBase>(agentObjectId, userIdentity);
 
                     await RunDataPipeline(


### PR DESCRIPTION
# Fix issue with incorrect tool name in file tool association

## The Azure DevOps work item being addressed

[AB#59](https://dev.azure.com/foundationallm/46965626-a028-4da9-83d3-9723c4aa1e02/_workitems/edit/59)

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
