### PR TITLE
Fix issue with resource name loosing casing

### DIFF
--- a/src/ui/UserPortal/pages/create-agent.vue
+++ b/src/ui/UserPortal/pages/create-agent.vue
@@ -530,11 +530,8 @@ export default defineComponent({
 
             let slug = displayName.trim();
 
-            // Convert to lowercase
-            slug = slug.toLowerCase();
-
-            // Remove special characters and keep only alphanumeric, hyphens, and underscores
-            slug = slug.replace(/[^a-z0-9\s-]/g, '');
+            // Remove special characters and keep only alphanumeric, hyphens, and underscores (preserve case)
+            slug = slug.replace(/[^a-zA-Z0-9\s_-]/g, '');
 
             // Replace multiple spaces with single hyphen
             slug = slug.replace(/\s+/g, '-');
@@ -548,6 +545,11 @@ export default defineComponent({
             // Ensure it's not empty
             if (!slug || slug.length === 0) {
                 slug = 'agent';
+            }
+
+            // Ensure it starts with a letter (required by resource name pattern)
+            if (slug.length > 0 && !/^[a-zA-Z]/.test(slug)) {
+                slug = 'agent-' + slug;
             }
             
             return slug;


### PR DESCRIPTION
# Fix issue with resource name loosing casing

## The Azure DevOps work item being addressed

[AB#78](https://dev.azure.com/foundationallm/46965626-a028-4da9-83d3-9723c4aa1e02/_workitems/edit/78)

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
