### PR TITLE
Use object ids without actions in resource provider authorization

### DIFF
--- a/src/dotnet/Common/Models/ResourceProviders/ResourcePath.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/ResourcePath.cs
@@ -485,7 +485,7 @@ namespace FoundationaLLM.Common.Models.ResourceProviders
                 resourcePath,
                 allowedResourceProviders,
                 allowedResourceTypes,
-                false,
+                true,
                 out ResourcePath? parsedResourcePath)
                 || parsedResourcePath is null)
                 throw new ResourcePathException($"The resource path [{resourcePath}] is invalid.");

--- a/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
+++ b/src/dotnet/Common/Services/ResourceProviders/ResourceProviderServiceBase.cs
@@ -967,7 +967,7 @@ namespace FoundationaLLM.Common.Services.ResourceProviders
                 bool useParentResourceInstance = false;
 
                 var authorizableAction = $"{_name}/{resourcePath.MainResourceTypeName!}/{actionType}";
-                var resourceObjectId = resourcePath.ObjectId
+                var resourceObjectId = resourcePath.ObjectIdWithoutAction
                     ?? throw new ResourceProviderException(
                         $"The resource path {resourcePath} does not nave a valid object identifier.",
                         StatusCodes.Status400BadRequest);


### PR DESCRIPTION
# Use object ids without actions in resource provider authorization

## The Azure DevOps work item being addressed

[AB#89](https://dev.azure.com/foundationallm/46965626-a028-4da9-83d3-9723c4aa1e02/_workitems/edit/89)

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
