### PR TITLE
MultipartPrompt is not derived from base classes

### DIFF
--- a/src/ui/UserPortal/js/types/index.ts
+++ b/src/ui/UserPortal/js/types/index.ts
@@ -222,19 +222,30 @@ export interface MessageResponse {
 	status_message?: string;
 }
 
-export interface ResourceBase {
-	type: string;
+
+export interface ResourceName {
+	type: string | null;
 	name: string;
-	object_id: string;
+}
+
+export interface ResourceBase extends ResourceName {
+	object_id?: string;
 	display_name?: string | null;
 	description?: string | null;
 	cost_center?: string | null;
+	properties?: Record<string, string>;
 	created_on?: string;
 	updated_on?: string;
 	created_by?: string | null;
 	updated_by?: string | null;
 	deleted?: boolean;
 	expiration_date?: string | null;
+	inheritable_authorizable_actions?: string[];
+}
+
+export interface PromptBase extends ResourceBase {
+	type: string | null;
+	category?: string | null;
 }
 
 
@@ -350,21 +361,7 @@ export interface AgentCreationFromTemplateRequest {
 }
 
 // --- MultipartPrompt Type ---
-export interface MultipartPrompt {
-	type: string;
-	name: string;
-	object_id: string;
-	display_name: string;
-	description: string;
-	cost_center?: string | null;
-	prefix: string;
+export interface MultipartPrompt extends PromptBase {
+	prefix?: string | null;
 	suffix?: string | null;
-	category?: string;
-	properties?: Record<string, any>;
-	created_on?: string;
-	updated_on?: string;
-	created_by?: string | null;
-	updated_by?: string;
-	deleted?: boolean;
-	expiration_date?: string | null;
 }


### PR DESCRIPTION
# MultipartPrompt is not derived from base classes

## The Azure DevOps work item being addressed

AB#96

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
