### PR TITLE
Fix issue with resource path when call by Open API

### DIFF
--- a/src/dotnet/Common/Models/ResourceProviders/ResourceBase.cs
+++ b/src/dotnet/Common/Models/ResourceProviders/ResourceBase.cs
@@ -19,7 +19,7 @@ namespace FoundationaLLM.Common.Models.ResourceProviders
         /// </summary>
         [JsonIgnore]
         public ResourcePath ResourcePath =>
-            ResourcePath.GetResourcePath(ObjectId!);
+            ResourcePath.GetResourcePath(ObjectId ?? "/");
 
         /// <summary>
         /// The display name of the resource.


### PR DESCRIPTION
# Fix issue with resource path when call by Open API

## The Azure DevOps work item being addressed

N/A

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [ ]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
