### PR TITLE
Fix issue with vector store filter when matching knowledge graph items

### DIFF
--- a/src/dotnet/ContextEngine/Services/KnowledgeUnitQueryEngine.cs
+++ b/src/dotnet/ContextEngine/Services/KnowledgeUnitQueryEngine.cs
@@ -97,8 +97,9 @@ namespace FoundationaLLM.Context.Services
                         vectorStoreFilter?.VectorStoreMetadataFilter);
 
                     _logger.LogInformation(
-                        "Filter for vector store {VectorStore} in knowledge unit {KnowledgeUnit}: {Filter}",
+                        "Vector store query - filter for vector store {VectorDatabase}/{VectorStore} in knowledge unit {KnowledgeUnit}: {Filter}",
                         _vectorDatabase.DatabaseName,
+                        vectorStoreId,
                         _knowledgeUnit.Name,
                         matchingDocumentsFilter);
 
@@ -200,8 +201,9 @@ namespace FoundationaLLM.Context.Services
                             vectorStoreFilter?.VectorStoreMetadataFilter);
 
                         _logger.LogInformation(
-                            "Filter for vector store {VectorStore} in knowledge unit {KnowledgeUnit}: {Filter}",
+                            "Vector store query (via KG) - filter for vector store {VectorDatabase}/{VectorStore} in knowledge unit {KnowledgeUnit}: {Filter}",
                             _vectorDatabase.DatabaseName,
+                            vectorStoreId,
                             _knowledgeUnit.Name,
                             matchingDocumentsFilter);
 
@@ -285,11 +287,12 @@ namespace FoundationaLLM.Context.Services
                         _vectorDatabase,
                         vectorStoreId,
                         [],
-                        vectorStoreFilter?.VectorStoreMetadataFilter);
+                        null);
 
             _logger.LogInformation(
-                "Filter for vector store {VectorStore} in knowledge unit {KnowledgeUnit}: {Filter}",
+                "Match knowledge graph items - filter for vector store {VectorDatabase}/{VectorStore} in knowledge unit {KnowledgeUnit}: {Filter}",
                 vectorDatabase.DatabaseName,
+                vectorStoreId,
                 _knowledgeUnit.Name,
                 matchingDocumentsFilter);
 


### PR DESCRIPTION
# Fix issue with vector store filter when matching knowledge graph items

## The Azure DevOps work item being addressed

N/A

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
