### PR TITLE
Fix issue with loading api key header name in API endpoint configuration

### DIFF
--- a/src/dotnet/Common/Services/API/HttpClientFactoryService.cs
+++ b/src/dotnet/Common/Services/API/HttpClientFactoryService.cs
@@ -76,11 +76,9 @@ namespace FoundationaLLM.Common.Services.API
             if (endpointConfiguration.AuthenticationType == AuthenticationTypes.APIKey)
             {
                 if (!endpointConfiguration.AuthenticationParameters.TryGetValue(
-                        AuthenticationParametersKeys.APIKeyHeaderName, out var apiKeyHeaderNameObj))
-                    throw new Exception($"The {AuthenticationParametersKeys.APIKeyHeaderName} key is missing from the enpoint's authentication parameters dictionary.");
-
-                clientBuilderParameters[HttpClientFactoryServiceKeyNames.APIKeyHeaderName] =
-                    apiKeyHeaderNameObj.ToString()!;
+                    AuthenticationParametersKeys.APIKeyHeaderName, out var apiKeyHeaderNameObj))
+                    clientBuilderParameters[HttpClientFactoryServiceKeyNames.APIKeyHeaderName] =
+                        apiKeyHeaderNameObj!.ToString()!;
 
                 if (!endpointConfiguration.AuthenticationParameters.TryGetValue(
                         AuthenticationParametersKeys.APIKeyConfigurationName, out var apiKeyConfigurationNameObj))
@@ -90,7 +88,7 @@ namespace FoundationaLLM.Common.Services.API
                 clientBuilderParameters[HttpClientFactoryServiceKeyNames.APIKey] = apiKey!;
 
                 if (endpointConfiguration.AuthenticationParameters.TryGetValue(
-                        AuthenticationParametersKeys.APIKeyPrefix, out var apiKeyPrefixObj))
+                    AuthenticationParametersKeys.APIKeyPrefix, out var apiKeyPrefixObj))
                     clientBuilderParameters[HttpClientFactoryServiceKeyNames.APIKeyHeaderName] =
                         apiKeyPrefixObj.ToString()!;
             }


### PR DESCRIPTION
# Fix issue with loading api key header name in API endpoint configuration

## The Azure DevOps work item being addressed

[AB#129](https://dev.azure.com/foundationallm/46965626-a028-4da9-83d3-9723c4aa1e02/_workitems/edit/129)

## Details on the issue fix or feature implementation

N/A

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  This PR needs to be cherry-picked into at least one release branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have included inline docs for my changes, where applicable
- [x]  I have successfully run a local build
- [ ]  I have provided the required update scripts, where applicable
- [ ]  I have updated relevant docs, where applicable

> [!NOTE]
> Instead of adding `X`'s inside the checkboxes you wish to check above, first submit the PR, then check the boxes in the rendered description.
